### PR TITLE
スケジュール取得apiエンドポイントの修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,9 +4,7 @@ on:
   # Trigger the workflow every time you push to the `main` branch
   # Using a different branch name? Replace `main` with your branch’s name
   push:
-    branches: [ master ]
-  schedule:
-    - cron: "0 9 * * *"
+    branches: [ main ]
   # Allows you to run this workflow manually from the Actions tab on GitHub.
   workflow_dispatch:
 

--- a/src/pages/schedule.astro
+++ b/src/pages/schedule.astro
@@ -97,7 +97,9 @@ import ProgressCircle from "@/atom/components/ui/progress-circle.astro";
     // ICSデータを取得する関数
     async function fetchIcsData(): Promise<Event[]> {
         try {
-            const response = await fetch("/api/utils/calendar");
+            const response = await fetch(
+                "https://omu-aikido-preview.vercel.app/api/utils/calendar"
+            );
             if (!response.ok) {
                 throw new Error(
                     `Failed to fetch ICS data: ${response.statusText}`


### PR DESCRIPTION
This pull request includes changes to the deployment workflow and the URL used to fetch ICS data. The most important changes are as follows:

### Workflow Configuration:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L7-R7): Updated the branch name from `master` to `main` for the push trigger and removed the scheduled cron job.

### Fetch URL Update:

* [`src/pages/schedule.astro`](diffhunk://#diff-82a686774d9539e57148986f5ccdd1606e0a5d35b9457308610645b40ff4faa4L100-R102): Changed the URL for fetching ICS data to use the preview environment's endpoint.