### PR TITLE
Create update_pages.yml

### DIFF
--- a/.github/workflows/update_pages.yml
+++ b/.github/workflows/update_pages.yml
@@ -1,0 +1,45 @@
+name: Deploy Astro to GitHub Pages
+
+on:
+  repository_dispatch:
+    types:
+      - pages_update
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up SSH key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.DEPLOY_PRIVATE_KEY }}
+          known_hosts: github.com
+
+      - name: Clone private repository
+        run: |
+          git clone git@github.com:omu-aikido/omu-aikido.git private-repo
+
+      - name: Move to project directory
+        run: cd static/page
+
+      - name: Install dependencies and build Astro site
+        run: |
+          npm install
+          npm run build
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      # GitHub Pagesへのデプロイ
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the deployment of an Astro site to GitHub Pages. The workflow is triggered by a repository dispatch event and includes steps for setting up an SSH key, cloning a private repository, building the Astro site, and deploying it to GitHub Pages.

Key changes:

* Added a new GitHub Actions workflow file `.github/workflows/update_pages.yml` to automate the deployment process.
* Configured the workflow to trigger on `repository_dispatch` events of type `pages_update`.
* Included steps for setting up an SSH key, cloning a private repository, installing dependencies, building the Astro site, and deploying to GitHub Pages.